### PR TITLE
Feat: initialize new client with db

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,0 +1,58 @@
+package supabase
+
+import (
+	"errors"
+
+	"github.com/supabase/postgrest-go"
+)
+
+const REST_URL = "/rest/v1"
+
+type Client struct {
+	rest *postgrest.Client
+}
+
+type RestOptions struct {
+	Schema string
+}
+
+type ClientOptions struct {
+	Headers map[string]string
+	Db      *RestOptions
+}
+
+func NewClient(url, key string, options *ClientOptions) (*Client, error) {
+	if url == "" || key == "" {
+		return nil, errors.New("url and key are required")
+	}
+
+	defaultHeaders := map[string]string{
+		"Authorization": "Bearer " + key,
+		"apikey":        key,
+	}
+
+	client := &Client{}
+	schema := "public"
+	if options != nil && options.Db != nil {
+		if len(options.Headers) > 0 {
+			for k, v := range options.Headers {
+				defaultHeaders[k] = v
+			}
+		}
+	}
+	client.rest = postgrest.NewClient(url+REST_URL, schema, defaultHeaders)
+
+	return client, nil
+}
+
+// Wrap postgrest From method
+// From returns a QueryBuilder for the specified table.
+func (c *Client) From(table string) *postgrest.QueryBuilder {
+	return c.rest.From(table)
+}
+
+// Wrap postgrest Rpc method
+// Rpc returns a string for the specified function.
+func (c *Client) Rpc(name, count string, rpcBody interface{}) string {
+	return c.rest.Rpc(name, count, rpcBody)
+}

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,31 @@
+package supabase_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/supabase-community/supabase-go"
+)
+
+const (
+	API_URL = "https://your-company.supabase.co"
+	API_KEY = "your-api-key"
+)
+
+func TestFrom(t *testing.T) {
+	client, err := supabase.NewClient(API_URL, API_KEY, nil)
+	if err != nil {
+		fmt.Println("cannot initalize client", err)
+	}
+	data, count, err := client.From("countries").Select("*", "exact", false).Execute()
+	fmt.Println(string(data), err, count)
+}
+
+func TestRpc(t *testing.T) {
+	client, err := supabase.NewClient(API_URL, API_KEY, nil)
+	if err != nil {
+		fmt.Println("cannot initalize client", err)
+	}
+	result := client.Rpc("hello_world", "", nil)
+	fmt.Println(result)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/supabase-community/supabase-go
+
+go 1.20
+
+require github.com/supabase/postgrest-go v0.0.7

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,14 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/jarcoal/httpmock v1.1.0 h1:F47ChZj1Y2zFsCXxNkBPwNNKnAyOATcdQibk0qEdVCE=
+github.com/jarcoal/httpmock v1.1.0/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/supabase/postgrest-go v0.0.7 h1:wkOzrndF/KliPEVHM84lNnET7ZFjAk1OPpAxz8hgzRs=
+github.com/supabase/postgrest-go v0.0.7/go.mod h1:sqnMeRGv0p8BzJX7busTdpT51tRdJHX9R5kd8oziovo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## What kind of change does this PR introduce?

Initialize new client for supabase-go client.

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Initial new client and start using db function like `postgres-go`
```
client, err := supabase.NewClient(API_URL, API_KEY, nil)
	if err != nil {
		fmt.Println("cannot initalize client", err)
	}
	data, count, err := client.From("countries").Select("*", "exact", false).Execute()
```

## Additional context

Add any other context or screenshots.
