### PR TITLE
Add/update headers and db schema with user provided ClientOptions to NewClient

### DIFF
--- a/client.go
+++ b/client.go
@@ -35,22 +35,32 @@ func NewClient(url, key string, options *ClientOptions) (*Client, error) {
 		return nil, errors.New("url and key are required")
 	}
 
-	defaultHeaders := map[string]string{
+	headers := map[string]string{
 		"Authorization": "Bearer " + key,
 		"apikey":        key,
 	}
 
-	client := &Client{}
-	schema := "public"
-	if options != nil && options.Db != nil {
-		if len(options.Headers) > 0 {
-			for k, v := range options.Headers {
-				defaultHeaders[k] = v
-			}
+	if options != nil && options.Headers != nil {
+		for k, v := range options.Headers {
+			headers[k] = v
 		}
 	}
-	client.rest = postgrest.NewClient(url+REST_URL, schema, defaultHeaders)
-	client.Storage = storage_go.NewClient(url+STORGAGE_URL, key, defaultHeaders)
+
+	var schema string
+	if options != nil && options.Db != nil && options.Db.Schema != "" {
+		schema = options.Db.Schema
+	} else {
+		schema = "public"
+	}
+	if options != nil && options.Headers != nil {
+		for k, v := range options.Headers {
+			headers[k] = v
+		}
+	}
+
+	client := &Client{}
+	client.rest = postgrest.NewClient(url+REST_URL, schema, headers)
+	client.Storage = storage_go.NewClient(url+STORGAGE_URL, key, headers)
 
 	return client, nil
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Currently, when a user passes in `ClientOptions` to `NewClient`, the user specified `Headers` and `Db` values are ignored when instantiating the postgrest client (and storage client in regards to headers only). This means that users are permanently stuck using the `public` schema, even when they specify their desired schema in the `ClientOptions`.

## What is the new behavior?

With these changes, the consumer of `NewClient` can have their specified headers added/updated in the headers `map`, along with a database schema specified by the user to be used by the postgrest client.

