### PR TITLE
Correct library installation command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ _Reminder: `supabase-go` has some APIs that require the `service_key` rather tha
 ### Get Started
 First of all, you need to install the library:
 ```sh
-  go install github.com/supabase-community/supabase-go
+  go get github.com/supabase-community/supabase-go
 ```
 
 Then you can use


### PR DESCRIPTION
The installation command should be:

```text
go get github.com/supabase-community/supabase-go
```

rather than

```text
go install github.com/supabase-community/supabase-go
```