### PR TITLE
Integrating realtime-go client

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ An isomorphic Go client for Supabase.
 
 ## Features
 
-- [ ] Integration with [Supabase.Realtime](https://github.com/supabase-community/realtime-go)
+- [X] Integration with [Supabase.Realtime](https://github.com/supabase-community/realtime-go)
   - Realtime listeners for database changes
 - [x] Integration with [Postgrest](https://github.com/supabase-community/postgrest-go)
   - Access your database using a REST API generated from your schema & database functions

--- a/client.go
+++ b/client.go
@@ -9,6 +9,7 @@ import (
 	"github.com/supabase-community/gotrue-go"
 	"github.com/supabase-community/gotrue-go/types"
 	postgrest "github.com/supabase-community/postgrest-go"
+	realtime "github.com/supabase-community/realtime-go/realtime"
 	storage_go "github.com/supabase-community/storage-go"
 )
 
@@ -26,6 +27,7 @@ type Client struct {
 	// Auth is an interface. We don't need a pointer to an interface.
 	Auth      gotrue.Client
 	Functions *functions.Client
+	Realtime  *realtime.RealtimeClient
 	options   clientOptions
 }
 
@@ -37,6 +39,7 @@ type clientOptions struct {
 type ClientOptions struct {
 	Headers map[string]string
 	Schema  string
+	RefId   string
 }
 
 // NewClient creates a new Supabase client.
@@ -78,6 +81,12 @@ func NewClient(url, key string, options *ClientOptions) (*Client, error) {
 	tmp := gotrue.New(url, key)
 	client.Auth = tmp.WithCustomGoTrueURL(url + AUTH_URL)
 	client.Functions = functions.NewClient(url+FUNCTIONS_URL, key, headers)
+	// Realtime client requires the project reference ID instead of the full URL
+	if options != nil && options.RefId != "" {
+		client.Realtime = realtime.CreateRealtimeClient(options.RefId, key)
+	} else {
+		log.Println("Error initializing realtime client. The project reference ID is required.")
+	}
 
 	return client, nil
 }

--- a/client_test.go
+++ b/client_test.go
@@ -10,6 +10,7 @@ import (
 const (
 	API_URL = "https://your-company.supabase.co"
 	API_KEY = "your-api-key"
+	REF_ID  = "your-project-ref-id"
 )
 
 func TestFrom(t *testing.T) {
@@ -46,4 +47,13 @@ func TestFunctions(t *testing.T) {
 	}
 	result, err := client.Functions.Invoke("hello_world", map[string]interface{}{"name": "world"})
 	fmt.Println(result, err)
+}
+
+func TestRealtime(t *testing.T) {
+	client, err := supabase.NewClient(API_URL, API_KEY, &supabase.ClientOptions{RefId: REF_ID})
+	if err != nil {
+		fmt.Println("cannot initalize client", err)
+	}
+	err = client.Realtime.Connect()
+	fmt.Println(err)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/supabase-community/supabase-go
 
-go 1.21.1
+go 1.22
 
 toolchain go1.22.1
 
@@ -9,12 +9,14 @@ require (
 	github.com/supabase-community/functions-go v0.0.0-20220927045802-22373e6cb51d
 	github.com/supabase-community/gotrue-go v1.2.0
 	github.com/supabase-community/postgrest-go v0.0.11
+	github.com/supabase-community/realtime-go v0.1.0
 	github.com/supabase-community/storage-go v0.7.0
 )
 
 require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 // indirect
+	nhooyr.io/websocket v1.8.11 // indirect
 )
 
 replace github.com/supabase-community/postgrest-go => github.com/roja/postgrest-go v0.0.11

--- a/go.sum
+++ b/go.sum
@@ -16,9 +16,13 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/supabase-community/gotrue-go v1.2.0 h1:Zm7T5q3qbuwPgC6xyomOBKrSb7X5dvmjDZEmNST7MoE=
 github.com/supabase-community/gotrue-go v1.2.0/go.mod h1:86DXBiAUNcbCfgbeOPEh0PQxScLfowUbYgakETSFQOw=
+github.com/supabase-community/realtime-go v0.1.0 h1:dr+1N3dNCY0o4y0+QQvzsUYoaX2dwZpCfg+9j2aNaOc=
+github.com/supabase-community/realtime-go v0.1.0/go.mod h1:JM3SgAceD6Rmpuxe2mvJKEU2NytuiYRrK9A0mqFWC7U=
 github.com/supabase-community/storage-go v0.7.0 h1:cJ8HLbbnL54H5rHPtHfiwtpRwcbDfA3in9HL/ucHnqA=
 github.com/supabase-community/storage-go v0.7.0/go.mod h1:oBKcJf5rcUXy3Uj9eS5wR6mvpwbmvkjOtAA+4tGcdvQ=
 github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 h1:nrZ3ySNYwJbSpD6ce9duiP+QkD3JuLCcWkdaehUS/3Y=
 github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80/go.mod h1:iFyPdL66DjUD96XmzVL3ZntbzcflLnznH0fr99w5VqE=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+nhooyr.io/websocket v1.8.11 h1:f/qXNc2/3DpoSZkHt1DQu6rj4zGC8JmkkLkWss0MgN0=
+nhooyr.io/websocket v1.8.11/go.mod h1:rN9OFWIUwuxg4fR5tELlYC04bXYowCP9GX47ivo2l+c=


### PR DESCRIPTION
## What kind of change does this PR introduce?

Integrates the current Supabase client with [realtime-go](https://github.com/supabase-community/realtime-go).

## What is the current behavior?

The current Supabase client lacks a connection with the Realtime API.

## What is the new behavior?

The realtime client is now available. It is necessary to inform the project reference id in the client options.

## Additional context

The [realtime-go](https://github.com/supabase-community/realtime-go) library does not need the full project URL to create a connection with the Realtime API. Instead, it only requires the project reference id.
