### PR TITLE
Add HTTP Proxy to ClientOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,17 @@ Then you can use
  client.SignInWithEmailPassword(USER_EMAIL, USER_PASSWORD)
 
 ```
+
+### Configure HTTP Proxy
+
+To configure an HTTP Proxy for the Supabase client, you can use the `Proxy` field in `ClientOptions`. Here's an example:
+
+```go
+  client, err := supabase.NewClient(API_URL, API_KEY, &supabase.ClientOptions{
+    Proxy: "http://your-proxy-url:port",
+  })
+  if err != nil {
+    fmt.Println("cannot initalize client", err)
+  }
+  data, count, err := client.From("countries").Select("*", "exact", false).Execute()
+```

--- a/client_test.go
+++ b/client_test.go
@@ -2,6 +2,8 @@ package supabase_test
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/supabase-community/supabase-go"
@@ -46,4 +48,95 @@ func TestFunctions(t *testing.T) {
 	}
 	result, err := client.Functions.Invoke("hello_world", map[string]interface{}{"name": "world"})
 	fmt.Println(result, err)
+}
+
+func TestFromWithProxy(t *testing.T) {
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`[{"id":1,"name":"Test Country"}]`))
+	}))
+	defer proxy.Close()
+
+	client, err := supabase.NewClient(API_URL, API_KEY, &supabase.ClientOptions{Proxy: proxy.URL})
+	if err != nil {
+		t.Fatalf("cannot initialize client: %v", err)
+	}
+
+	data, count, err := client.From("countries").Select("*", "exact", false).Execute()
+	if err != nil {
+		t.Fatalf("error executing query: %v", err)
+	}
+
+	expected := `[{"id":1,"name":"Test Country"}]`
+	if string(data) != expected {
+		t.Errorf("expected %s, got %s", expected, string(data))
+	}
+	if count != 1 {
+		t.Errorf("expected count 1, got %d", count)
+	}
+}
+
+func TestRpcWithProxy(t *testing.T) {
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`"Hello, world!"`))
+	}))
+	defer proxy.Close()
+
+	client, err := supabase.NewClient(API_URL, API_KEY, &supabase.ClientOptions{Proxy: proxy.URL})
+	if err != nil {
+		t.Fatalf("cannot initialize client: %v", err)
+	}
+
+	result := client.Rpc("hello_world", "", nil)
+	expected := `"Hello, world!"`
+	if result != expected {
+		t.Errorf("expected %s, got %s", expected, result)
+	}
+}
+
+func TestStorageWithProxy(t *testing.T) {
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"id":"bucket-id","name":"Test Bucket"}`))
+	}))
+	defer proxy.Close()
+
+	client, err := supabase.NewClient(API_URL, API_KEY, &supabase.ClientOptions{Proxy: proxy.URL})
+	if err != nil {
+		t.Fatalf("cannot initialize client: %v", err)
+	}
+
+	result, err := client.Storage.GetBucket("bucket-id")
+	if err != nil {
+		t.Fatalf("error getting bucket: %v", err)
+	}
+
+	expected := `{"id":"bucket-id","name":"Test Bucket"}`
+	if result != expected {
+		t.Errorf("expected %s, got %s", expected, result)
+	}
+}
+
+func TestFunctionsWithProxy(t *testing.T) {
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"message":"Hello, world!"}`))
+	}))
+	defer proxy.Close()
+
+	client, err := supabase.NewClient(API_URL, API_KEY, &supabase.ClientOptions{Proxy: proxy.URL})
+	if err != nil {
+		t.Fatalf("cannot initialize client: %v", err)
+	}
+
+	result, err := client.Functions.Invoke("hello_world", map[string]interface{}{"name": "world"})
+	if err != nil {
+		t.Fatalf("error invoking function: %v", err)
+	}
+
+	expected := `{"message":"Hello, world!"}`
+	if result != expected {
+		t.Errorf("expected %s, got %s", expected, result)
+	}
 }


### PR DESCRIPTION
Fixes #26

Add HTTP Proxy support to ClientOptions.

* **client.go**
  - Add `Proxy` field to `ClientOptions` struct to configure HTTP Proxy.
  - Update `NewClient` function to use `Proxy` field if provided.
  - Update `clientOptions` struct to include `proxy` field.
  - Update `NewClient` function to set `proxy` field in `clientOptions`.

* **client_test.go**
  - Add test cases to verify HTTP Proxy functionality in `TestFrom`.
  - Add test cases to verify HTTP Proxy functionality in `TestRpc`.
  - Add test cases to verify HTTP Proxy functionality in `TestStorage`.
  - Add test cases to verify HTTP Proxy functionality in `TestFunctions`.

* **README.md**
  - Add documentation on how to configure HTTP Proxy in `ClientOptions`.
  - Add example code snippet for configuring HTTP Proxy.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/supabase-community/supabase-go/pull/27?shareId=ffb0b7b4-fff8-4179-becc-9ffdafd74f3f).