### PR TITLE
chore: Update to use auth-go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Test binary, generated with `go test -c`
+*.test
+
+# Output of the go build command
+/bin/
+/pkg/
+
+
+# IDE specific files
+.idea/
+.vscode/
+
+# Local environment variables
+.env
+.env.*

--- a/client_test.go
+++ b/client_test.go
@@ -15,7 +15,7 @@ const (
 func TestFrom(t *testing.T) {
 	client, err := supabase.NewClient(API_URL, API_KEY, nil)
 	if err != nil {
-		fmt.Println("cannot initalize client", err)
+		fmt.Println("cannot initialize client", err)
 	}
 	data, count, err := client.From("countries").Select("*", "exact", false).Execute()
 	fmt.Println(string(data), err, count)
@@ -24,7 +24,7 @@ func TestFrom(t *testing.T) {
 func TestRpc(t *testing.T) {
 	client, err := supabase.NewClient(API_URL, API_KEY, nil)
 	if err != nil {
-		fmt.Println("cannot initalize client", err)
+		fmt.Println("cannot initialize client", err)
 	}
 	result := client.Rpc("hello_world", "", nil)
 	fmt.Println(result)
@@ -33,7 +33,7 @@ func TestRpc(t *testing.T) {
 func TestStorage(t *testing.T) {
 	client, err := supabase.NewClient(API_URL, API_KEY, nil)
 	if err != nil {
-		fmt.Println("cannot initalize client", err)
+		fmt.Println("cannot initialize client", err)
 	}
 	result, err := client.Storage.GetBucket("bucket-id")
 	fmt.Println(result, err)
@@ -42,7 +42,7 @@ func TestStorage(t *testing.T) {
 func TestFunctions(t *testing.T) {
 	client, err := supabase.NewClient(API_URL, API_KEY, nil)
 	if err != nil {
-		fmt.Println("cannot initalize client", err)
+		fmt.Println("cannot initialize client", err)
 	}
 	result, err := client.Functions.Invoke("hello_world", map[string]interface{}{"name": "world"})
 	fmt.Println(result, err)

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ toolchain go1.22.1
 
 require (
 	github.com/joho/godotenv v1.5.1
+	github.com/supabase-community/auth-go v1.4.0
 	github.com/supabase-community/functions-go v0.0.0-20220927045802-22373e6cb51d
-	github.com/supabase-community/gotrue-go v1.2.0
 	github.com/supabase-community/postgrest-go v0.0.11
 	github.com/supabase-community/storage-go v0.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/roja/postgrest-go v0.0.11 h1:vGgsfL4+Tvkpbukneo4fPy/43gbeWSSlKmum9+pw
 github.com/roja/postgrest-go v0.0.11/go.mod h1:cw6LfzMyK42AOSBA1bQ/HZ381trIJyuui2GWhraW7Cc=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/supabase-community/gotrue-go v1.2.0 h1:Zm7T5q3qbuwPgC6xyomOBKrSb7X5dvmjDZEmNST7MoE=
-github.com/supabase-community/gotrue-go v1.2.0/go.mod h1:86DXBiAUNcbCfgbeOPEh0PQxScLfowUbYgakETSFQOw=
+github.com/supabase-community/auth-go v1.4.0 h1:5dS0NB9TKdT3zwaQqHJhrTFXvAcIC2/EDVC9dEV0wnY=
+github.com/supabase-community/auth-go v1.4.0/go.mod h1:Ww/iTwJNJZh//HwEl0i/vgC2JUgRwU+s3B8HfBqClas=
 github.com/supabase-community/storage-go v0.7.0 h1:cJ8HLbbnL54H5rHPtHfiwtpRwcbDfA3in9HL/ucHnqA=
 github.com/supabase-community/storage-go v0.7.0/go.mod h1:oBKcJf5rcUXy3Uj9eS5wR6mvpwbmvkjOtAA+4tGcdvQ=
 github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 h1:nrZ3ySNYwJbSpD6ce9duiP+QkD3JuLCcWkdaehUS/3Y=

--- a/test/remote_client.go
+++ b/test/remote_client.go
@@ -1,4 +1,4 @@
-// This is basic example for postgrest-go library usage.
+	// This is basic example for postgrest-go library usage.
 // For now this example is represent wanted syntax and bindings for library.
 // After core development this test files will be used for CI tests.
 
@@ -26,7 +26,7 @@ func main() {
 
 	client, err := supabase.NewClient(projectURL, anonKey, nil)
 	if err != nil {
-		fmt.Println("cannot initalize client", err)
+		fmt.Println("cannot initialize client", err)
 	}
 	client.SignInWithEmailPassword(email, password)
 

--- a/test/remote_client.go
+++ b/test/remote_client.go
@@ -1,4 +1,4 @@
-	// This is basic example for postgrest-go library usage.
+// This is basic example for postgrest-go library usage.
 // For now this example is represent wanted syntax and bindings for library.
 // After core development this test files will be used for CI tests.
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
- Migrate to use auth-go library

## Additional context

- https://github.com/supabase-community/gotrue-go is archived
- has a message saying to use https://github.com/supabase-community/auth-go instead


