### PR TITLE
chore: updated existing tests to use golang testing api

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -1,7 +1,6 @@
 package supabase_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/supabase-community/supabase-go"
@@ -12,38 +11,55 @@ const (
 	API_KEY = "your-api-key"
 )
 
+func TestNewClient(t *testing.T) {
+	client, err := supabase.NewClient(API_URL, API_KEY, nil)
+	if err != nil {
+		t.Errorf("cannot initialize client: %v", err)
+	}
+	t.Logf("newClient result: %v", client)
+}
+
 func TestFrom(t *testing.T) {
 	client, err := supabase.NewClient(API_URL, API_KEY, nil)
 	if err != nil {
-		fmt.Println("cannot initialize client", err)
+		t.Errorf("cannot initialize client: %v", err)
 	}
 	data, count, err := client.From("countries").Select("*", "exact", false).Execute()
-	fmt.Println(string(data), err, count)
+	if err != nil {
+		t.Errorf("cannot perform From operation: %v", err)
+	}
+	t.Logf("%s%v%d", data, err, count)
 }
 
 func TestRpc(t *testing.T) {
 	client, err := supabase.NewClient(API_URL, API_KEY, nil)
 	if err != nil {
-		fmt.Println("cannot initialize client", err)
+		t.Errorf("cannot initialize client: %v", err)
 	}
 	result := client.Rpc("hello_world", "", nil)
-	fmt.Println(result)
+	t.Logf("rpc result: %s", result)
 }
 
 func TestStorage(t *testing.T) {
 	client, err := supabase.NewClient(API_URL, API_KEY, nil)
 	if err != nil {
-		fmt.Println("cannot initialize client", err)
+		t.Errorf("cannot initialize client: %v", err)
 	}
-	result, err := client.Storage.GetBucket("bucket-id")
-	fmt.Println(result, err)
+	bucket, err := client.Storage.GetBucket("bucket-id")
+	if err != nil {
+		t.Errorf("cannot get bucket: %v", err)
+	}
+	t.Logf("getBucket result: %v", bucket)
 }
 
 func TestFunctions(t *testing.T) {
 	client, err := supabase.NewClient(API_URL, API_KEY, nil)
 	if err != nil {
-		fmt.Println("cannot initialize client", err)
+		t.Errorf("cannot initialize client: %v", err)
 	}
 	result, err := client.Functions.Invoke("hello_world", map[string]interface{}{"name": "world"})
-	fmt.Println(result, err)
+	if err != nil {
+		t.Errorf("cannot invoke function: %v", err)
+	}
+	t.Logf("function invokation result: %v", result)
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Updated the tests to use the testing api instead of printing to stdout, as well as adding a simple test for creating a new client

## What is the current behavior?

Currently, the tests use the fmt package and print messages to stdout and do not make use of the testing api to pass/fail tests. Also, some errors are not checked.
Related issue(s): #35 

## What is the new behavior?

All logging happens using the testing api's log functionality, and tests fail if an error is thrown.

