### PR TITLE
expose client error

### DIFF
--- a/client.go
+++ b/client.go
@@ -92,6 +92,14 @@ func (c *Client) Rpc(name, count string, rpcBody interface{}) string {
 	return c.rest.Rpc(name, count, rpcBody)
 }
 
+// ClientError returns the last error that occurred during a request.
+// Generally, this should be checked only if the result of another method is
+// nil or empty. The error is not cleared after each call, so checking that it
+// is nil does not guarantee that the last request was successful.
+func (c *Client) ClientError() error {
+	return c.rest.ClientError
+}
+
 func (c *Client) SignInWithEmailPassword(email, password string) (types.Session, error) {
 	resp, err := c.Auth.SignInWithEmailPassword(email, password)
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -92,6 +92,12 @@ func (c *Client) Rpc(name, count string, rpcBody interface{}) string {
 	return c.rest.Rpc(name, count, rpcBody)
 }
 
+// Wrap postgrest Rpc method
+// Rpc returns a string for the specified function.
+func (c *Client) RpcWithError(name, count string, rpcBody interface{}) (string, error) {
+	return c.rest.RpcWithError(name, count, rpcBody)
+}
+
 // ClientError returns the last error that occurred during a request.
 // Generally, this should be checked only if the result of another method is
 // nil or empty. The error is not cleared after each call, so checking that it

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,6 @@ require (
 	github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 // indirect
 )
 
-replace github.com/supabase-community/postgrest-go => github.com/roja/postgrest-go v0.0.11
+replace github.com/supabase-community/postgrest-go => github.com/stevenctl/postgrest-go v0.0.0-20251107080813-0095e2979782
 
 replace github.com/supabase-community/functions-go => github.com/roja/functions-go v0.0.2

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/roja/functions-go v0.0.2 h1:fh+1XHtZ7HdJJAwHoJCyT6IHIHXIBpQ6fcS4dWDCKtI=
 github.com/roja/functions-go v0.0.2/go.mod h1:nnIju6x3+OZSojtGQCQzu0h3kv4HdIZk+UWCnNxtSak=
-github.com/roja/postgrest-go v0.0.11 h1:vGgsfL4+Tvkpbukneo4fPy/43gbeWSSlKmum9+pwDCI=
-github.com/roja/postgrest-go v0.0.11/go.mod h1:cw6LfzMyK42AOSBA1bQ/HZ381trIJyuui2GWhraW7Cc=
+github.com/stevenctl/postgrest-go v0.0.0-20251107080813-0095e2979782 h1:2jiUJaaQwwZm5W8nYIFBifxYfLkueNXhKSPXr8wLcLM=
+github.com/stevenctl/postgrest-go v0.0.0-20251107080813-0095e2979782/go.mod h1:cw6LfzMyK42AOSBA1bQ/HZ381trIJyuui2GWhraW7Cc=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/supabase-community/auth-go v1.4.0 h1:5dS0NB9TKdT3zwaQqHJhrTFXvAcIC2/EDVC9dEV0wnY=


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

There is no way to see error caused by methods such as `Rpc`

## What is the new behavior?

Simply passing through the ClientError field on the postrest client

## Additional context

It might make sense to change certain method, or create variants of other methods that return `(something, error)` that check this so callers don't need to understand when `ClientError` is relevant to the specific call they want to make. 